### PR TITLE
fix: pass error code 500 if error.status is undefined

### DIFF
--- a/src/Controller/AuthMiddleware.ts
+++ b/src/Controller/AuthMiddleware.ts
@@ -62,7 +62,7 @@ export class AuthMiddleware extends BaseMiddleware {
       if (error.response?.header?.['content-type']) {
         response.setHeader('content-type', error.response.header['content-type'])
       }
-      response.status(error.status).send(error.response ? error.response.body : error.message)
+      response.status(error.status || 500).send(error.response ? error.response.body : error.message)
 
       return
     }


### PR DESCRIPTION
Responding to the following error message:

```
node:internal/process/promises:245
          triggerUncaughtException(err, true /* fromPromise */);
          ^
RangeError [ERR_HTTP_INVALID_STATUS_CODE]: Invalid status code: undefined
    at new NodeError (node:internal/errors:329:5)
    at ServerResponse.writeHead (node:_http_server:279:11)
    at ServerResponse._implicitHeader (node:_http_server:270:8)
    at write_ (node:_http_outgoing:746:9)
    at ServerResponse.end (node:_http_outgoing:835:5)
    at ServerResponse.send (/var/www/node_modules/inversify-express-utils/node_modules/express/lib/response.js:221:10)
    at AuthMiddleware.<anonymous> (/var/www/dist/src/Controller/AuthMiddleware.js:73:47)
    at Generator.throw (<anonymous>)
    at rejected (/var/www/dist/src/Controller/AuthMiddleware.js:18:65)
    at processTicksAndRejections (node:internal/process/task_queues:94:5) {
  code: 'ERR_HTTP_INVALID_STATUS_CODE'
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```