### PR TITLE
fix: error code 500 when error.status is undefined in HttpService

### DIFF
--- a/src/Controller/AuthMiddleware.ts
+++ b/src/Controller/AuthMiddleware.ts
@@ -62,7 +62,7 @@ export class AuthMiddleware extends BaseMiddleware {
       if (error.response?.header?.['content-type']) {
         response.setHeader('content-type', error.response.header['content-type'])
       }
-      response.status(error.status).send(error.response ? error.response.body : error.message)
+      response.status(error.status || 500).send(error.response ? error.response.body : error.message)
 
       return
     }

--- a/src/Service/HttpService.ts
+++ b/src/Service/HttpService.ts
@@ -71,7 +71,7 @@ export class HttpService implements HttpServiceInterface {
       if (error.response?.header?.['content-type']) {
         response.setHeader('content-type', error.response.header['content-type'])
       }
-      response.status(error.status).send(error.response ? error.response.body : error.message)
+      response.status(error.status || 500).send(error.response ? error.response.body : error.message)
     }
 
     return


### PR DESCRIPTION
Sry, I forgot to check for duplicate code and missed the one in HttpService.

Here my new Error message:

```
RangeError [ERR_HTTP_INVALID_STATUS_CODE]: Invalid status code: undefined
    at new NodeError (node:internal/errors:329:5)
    at ServerResponse.writeHead (node:_http_server:279:11)
    at ServerResponse._implicitHeader (node:_http_server:270:8)
    at write_ (node:_http_outgoing:746:9)
    at ServerResponse.end (node:_http_outgoing:835:5)
    at ServerResponse.send (/var/www/node_modules/inversify-express-utils/node_modules/express/lib/response.js:221:10)
    at HttpService.<anonymous> (/var/www/dist/src/Service/HttpService.js:87:47)
    at Generator.throw (<anonymous>)
    at rejected (/var/www/dist/src/Service/HttpService.js:18:65)
    at processTicksAndRejections (node:internal/process/task_queues:94:5)
```